### PR TITLE
Add `Name` Component to Performance UI Setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Notable user-facing changes with each release version will be described in this file.
 
+## Unreleased
+
+Fixed:
+ - Default PerfUi component was lacking a name in the entity hierarchy.
+
 ## [0.3.0]: 2024-07-06
 
 Added:

--- a/src/ui/root.rs
+++ b/src/ui/root.rs
@@ -209,6 +209,7 @@ pub(crate) fn setup_perf_ui(
             *style = new_style;
         } else {
             commands.entity(e).insert((
+                Name::new("PerfUi"),
                 BackgroundColor(perf_ui.background_color),
                 new_style
             ));


### PR DESCRIPTION
# Add Name Component

Previously, the entity for the performance UI was lacking a `Name` component, making it difficult to search in tools like the  https://github.com/jakobhellermann/bevy-inspector-egui. 

This is a fix for #18.

<details><summary>Example Inspector EGUI</summary>
<p>

![CleanShot 2025-02-04 at 14 24 47@2x](https://github.com/user-attachments/assets/1899ce9f-64aa-44ed-9d8d-3914c2a30e64)

</p>
</details> 

## Changes

* Added `Name` component to UI setup.
